### PR TITLE
feat: update roslyn version for csharp image

### DIFF
--- a/entry/csharp.sh
+++ b/entry/csharp.sh
@@ -1,1 +1,1 @@
-csc source.cs $@ -nologo -unsafe -out:/tmp/run && mono /tmp/run
+csc source.cs /tmp/GlobalUsings.cs $@ -nologo -unsafe -out:/tmp/run && mono /tmp/run

--- a/scripts/extra_setup/csharp.sh
+++ b/scripts/extra_setup/csharp.sh
@@ -1,0 +1,14 @@
+wget https://www.nuget.org/api/v2/package/Microsoft.Net.Compilers.Toolset/4.11.0 -O /tmp/Microsoft.Net.Compilers.Toolset.nupkg
+unzip /tmp/Microsoft.Net.Compilers.Toolset.nupkg -d /tmp/Microsoft.Net.Compilers.Toolset
+mv /tmp/Microsoft.Net.Compilers.Toolset/tasks/net472/* /usr/lib/mono/4.5/
+rm -rf /tmp/Microsoft.Net.Compilers.Toolset
+
+echo -e "
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.IO;
+global using global::System.Linq;
+global using global::System.Net.Http;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;
+" > /tmp/GlobalUsings.cs

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -51,7 +51,7 @@ declare -A langs=(
     [zig]='zig'
     [nim]='nim gcc'
     [d]='gcc-gdc'
-    [csharp]='&& apk add mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing'
+    [csharp]='wget && apk add mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing'
     [rscript]='R'
     [dart]='&& apk add dart --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing'
 )

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -41,7 +41,7 @@ declare -A langs=(
     [20]='const std = @import("std");pub fn main() !void { std.io.getStdOut().writeAll("Success!") catch unreachable; }'
     [21]='echo "Success!"'
     [22]='import std.stdio; void main() { writeln("Success!"); }'
-    [23]='System.Console.WriteLine("Success!");'
+    [23]='Console.WriteLine("Success!");'
     [24]='print("Success!")'
     [25]='void main() { print("Success!"); }'
 )


### PR DESCRIPTION
## Title
Update the version of roslyn used by mono

## Type of Change
- [x] New feature

## Description
By default roslyn included with mono distribution is C# 9, we manually download and update roslyn so we can get the latest C# version

## Testing
Tested manually and added to the tests script

## Impact
Extra steps to build the csharp image

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings 
